### PR TITLE
Bridge pattern

### DIFF
--- a/src/main/java/com/rstyle/maxmoto1702/Main.java
+++ b/src/main/java/com/rstyle/maxmoto1702/Main.java
@@ -1,7 +1,8 @@
 package com.rstyle.maxmoto1702;
 
-import com.rstyle.maxmoto1702.desingpatterns.AbstractFactoryDemo;
+import com.rstyle.maxmoto1702.desingpatterns.AbstractFactoryPatternDemo;
 import com.rstyle.maxmoto1702.desingpatterns.AdapterPatternDemo;
+import com.rstyle.maxmoto1702.desingpatterns.BridgePatternDemo;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -9,8 +10,9 @@ public class Main {
     private static Logger LOG = LoggerFactory.getLogger(Main.class);
 
     public static void main(String... args) {
-        AbstractFactoryDemo.main(args);
+        AbstractFactoryPatternDemo.main(args);
         AdapterPatternDemo.main(args);
+        BridgePatternDemo.main(args);
     }
 
     public int method() {

--- a/src/main/java/com/rstyle/maxmoto1702/desingpatterns/AbstractFactoryPatternDemo.java
+++ b/src/main/java/com/rstyle/maxmoto1702/desingpatterns/AbstractFactoryPatternDemo.java
@@ -20,7 +20,7 @@ import com.rstyle.maxmoto1702.desingpatterns.abstractfactory.factories.FactoryPr
  *
  *
  */
-public class AbstractFactoryDemo {
+public class AbstractFactoryPatternDemo {
 
     public static void main(String... args) {
 

--- a/src/main/java/com/rstyle/maxmoto1702/desingpatterns/BridgePatternDemo.java
+++ b/src/main/java/com/rstyle/maxmoto1702/desingpatterns/BridgePatternDemo.java
@@ -1,0 +1,27 @@
+package com.rstyle.maxmoto1702.desingpatterns;
+
+import com.rstyle.maxmoto1702.desingpatterns.bridge.Circle;
+import com.rstyle.maxmoto1702.desingpatterns.bridge.GreenCircle;
+import com.rstyle.maxmoto1702.desingpatterns.bridge.RedCircle;
+import com.rstyle.maxmoto1702.desingpatterns.bridge.Shape;
+
+/**
+ * Created by m on 12.04.2015.
+ * Bridge is used when we need to decouple an abstraction from its implementation so that the two can vary independently.
+ * This type of design pattern comes under structural pattern as this pattern decouples implementation class and abstract
+ * class by providing a bridge structure between them.
+ * This pattern involves an interface which acts as a bridge which makes the functionality of concrete classes independent
+ * from interface implementer classes. Both types of classes can be altered structurally without affecting each other.
+ * We are demonstrating use of Bridge pattern via following example in which a circle can be drawn in different colors
+ * using same abstract class method but different bridge implementer classes.
+ */
+public class BridgePatternDemo {
+
+    public static void main(String... args) {
+        Shape redCircle = new Circle(100, 100, 10, new RedCircle());
+        Shape greenCircle = new Circle(100, 100, 10, new GreenCircle());
+
+        redCircle.draw();
+        greenCircle.draw();
+    }
+}

--- a/src/main/java/com/rstyle/maxmoto1702/desingpatterns/bridge/Circle.java
+++ b/src/main/java/com/rstyle/maxmoto1702/desingpatterns/bridge/Circle.java
@@ -1,0 +1,20 @@
+package com.rstyle.maxmoto1702.desingpatterns.bridge;
+
+/**
+ * Created by m on 12.04.2015.
+ */
+public class Circle extends Shape {
+    int x, y, radius;
+
+    public Circle(int x, int y, int radius, DrawAPI drawAPI) {
+        super(drawAPI);
+        this.x = x;
+        this.y = y;
+        this.radius = radius;
+    }
+
+    @Override
+    public void draw() {
+        drawAPI.drawCircle(radius, x, y);
+    }
+}

--- a/src/main/java/com/rstyle/maxmoto1702/desingpatterns/bridge/DrawAPI.java
+++ b/src/main/java/com/rstyle/maxmoto1702/desingpatterns/bridge/DrawAPI.java
@@ -1,0 +1,8 @@
+package com.rstyle.maxmoto1702.desingpatterns.bridge;
+
+/**
+ * Created by m on 12.04.2015.
+ */
+public interface DrawAPI {
+    void drawCircle(int radius, int x, int y);
+}

--- a/src/main/java/com/rstyle/maxmoto1702/desingpatterns/bridge/GreenCircle.java
+++ b/src/main/java/com/rstyle/maxmoto1702/desingpatterns/bridge/GreenCircle.java
@@ -1,0 +1,17 @@
+package com.rstyle.maxmoto1702.desingpatterns.bridge;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Created by m on 12.04.2015.
+ */
+public class GreenCircle implements DrawAPI {
+
+    private static final Logger LOG = LoggerFactory.getLogger(GreenCircle.class);
+
+    @Override
+    public void drawCircle(int radius, int x, int y) {
+        LOG.info("Drawing Circle[ color: green, radius: " + radius + ", x: " + x + ", " + y + "]");
+    }
+}

--- a/src/main/java/com/rstyle/maxmoto1702/desingpatterns/bridge/RedCircle.java
+++ b/src/main/java/com/rstyle/maxmoto1702/desingpatterns/bridge/RedCircle.java
@@ -1,0 +1,17 @@
+package com.rstyle.maxmoto1702.desingpatterns.bridge;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Created by m on 12.04.2015.
+ */
+public class RedCircle implements DrawAPI {
+
+    private static final Logger LOG = LoggerFactory.getLogger(RedCircle.class);
+
+    @Override
+    public void drawCircle(int radius, int x, int y) {
+        LOG.info("Drawing Circle[ color: red, radius: " + radius + ", x: " + x + ", " + y + "]");
+    }
+}

--- a/src/main/java/com/rstyle/maxmoto1702/desingpatterns/bridge/Shape.java
+++ b/src/main/java/com/rstyle/maxmoto1702/desingpatterns/bridge/Shape.java
@@ -1,0 +1,20 @@
+package com.rstyle.maxmoto1702.desingpatterns.bridge;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Created by m on 12.04.2015.
+ */
+public abstract class Shape {
+
+    private static final Logger LOG = LoggerFactory.getLogger(Shape.class);
+
+    protected DrawAPI drawAPI;
+
+    protected Shape(DrawAPI drawAPI) {
+        this.drawAPI = drawAPI;
+    }
+
+    public abstract void draw();
+}


### PR DESCRIPTION
Bridge is used when we need to decouple an abstraction from its implementation so that the two can vary independently. This type of design pattern comes under structural pattern as this pattern decouples implementation class and abstract class by providing a bridge structure between them.
This pattern involves an interface which acts as a bridge which makes the functionality of concrete classes independent from interface implementer classes. Both types of classes can be altered structurally without affecting each other.

We are demonstrating use of Bridge pattern via following example in which a circle can be drawn in different colors using same abstract class method but different bridge implementer classes.
